### PR TITLE
Use boost thread pool for command pooling

### DIFF
--- a/src/controller/CMakeLists.txt
+++ b/src/controller/CMakeLists.txt
@@ -17,6 +17,8 @@ set(SOURCES
         )
 
 add_library(${PROJECT_NAME} ${SOURCES})
+
+find_package(Boost COMPONENTS system REQUIRED)
 include_directories(${Boost_INCLUDE_DIRS})
 
 add_definitions(-DBOOST_LOG_DYN_LINK)

--- a/src/controller/command_executor.h
+++ b/src/controller/command_executor.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <boost/asio.hpp>
 #include "command_map.h"
 #include "handle_map.h"
 
@@ -21,7 +22,7 @@ namespace goliath::commands {
          * @param commands Command Map
          * @param handles Handle Map
          */
-        CommandExecutor(CommandMap& commands, HandleMap &handles);
+        CommandExecutor(size_t numberOfThreads, CommandMap& commands, HandleMap &handles);
         ~CommandExecutor();
 
         /**
@@ -31,15 +32,7 @@ namespace goliath::commands {
          * @param message Arguments gathered from the protobuf input
          */
         void run(size_t commandId, const CommandMessage &message);
-        /**
-         * @brief Running on it's own thread. Checks if the handles the command requires  are occupied. If so, call
-         * interrupt() on all command's currently using the handles the new command requires. After that waits for
-         * the condition variable to be triggered to then check again. If all handles are free, execute the command
-         * in the current thread. Sets status to started.
-         * @param commandId ID of the command to try to execute
-         * @param message Arguments gathered from the protobuf input
-         */
-        void tryExecute(const size_t &commandId, const CommandMessage &message);
+
         /**
          * @brief Checks if a command can start by checking all the handles it occupies
          * @param command Command to check the occupying handles of
@@ -47,11 +40,23 @@ namespace goliath::commands {
          */
         bool canStart(const Command &command) const;
     private:
-        std::vector<std::thread> threads;
-
+        const size_t numberOfThreads;
         CommandMap& commands;
         HandleMap& handles;
 
+        size_t numberOfActiveCommands;
+        boost::asio::thread_pool pool;
+
         std::mutex mutex;
+
+        /**
+         * Running on it's own thread. Checks if the handles the command requires  are occupied. If so, call
+         * interrupt() on all command's currently using the handles the new command requires. After that waits for
+         * the condition variable to be triggered to then check again. If all handles are free, execute the command
+         * in the current thread. Sets status to started.
+         * @param commandId ID of the command to try to execute
+         * @param message Arguments gathered from the protobuf input
+         */
+        void tryExecute(const size_t &commandId, const CommandMessage &message);
     };
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -54,7 +54,7 @@ int main(int argc, char *argv[]) {
     emotions::EmotionPublisher emotionPublisher(context, config->emotions().host(), config->emotions().port());
 
     BOOST_LOG_TRIVIAL(info) << "Setting up watcher";
-    repositories::Watcher watcher(500, publisher);
+    repositories::Watcher watcher(config->watcher().polling_rate(), publisher);
     auto battery_repo = std::make_shared<repositories::BatteryRepository>();
     watcher.watch(battery_repo);
 
@@ -123,7 +123,7 @@ int main(int argc, char *argv[]) {
     commands.add<commands::WunderhornCommand>(CommandMessage::kWunderhornCommand);
     commands.add<commands::MoveTowerCommand>(CommandMessage::kMoveTowerCommand);
 
-    commands::CommandExecutor runner(commands, handles);
+    commands::CommandExecutor runner(config->command_executor().number_of_executors(), commands, handles);
 
     subscriber.bind(MessageCarrier::MessageCase::kCommandMessage, [&runner](const MessageCarrier &carrier) {
         CommandMessage message = carrier.commandmessage();

--- a/src/resources/core-config.json
+++ b/src/resources/core-config.json
@@ -1,64 +1,70 @@
 {
-    "zmq": {
-        "subscriber_port": 5555,
-        "publisher_port": 5556
-    },
-    "serial": {
-        "port": "/dev/serial0",
-        "baudrate": "1000000"
-    },
-    "gpio": {
-        "pin": 18
-    },
-    "vision": {
-        "webcam": 0
-    },
-    "servos": {
-        "wings": [
-            {
-                "position": "LEFT_FRONT",
-                "id": "1"
-            },
-            {
-                "position": "LEFT_BACK",
-                "id": "2"
-            },
-            {
-                "position": "RIGHT_FRONT",
-                "id": "3"
-            },
-            {
-                "position": "RIGHT_BACK",
-                "id": "4"
-            }
-        ]
-    },
-    "i2c": {
-        "device": "/dev/i2c-1"
-    },
-    "motor_controller": {
-        "address": "0x30",
-        "motors": [
-            {
-                "position": "LEFT_FRONT",
-                "id": "0"
-            },
-            {
-                "position": "LEFT_BACK",
-                "id": "1"
-            },
-            {
-                "position": "RIGHT_FRONT",
-                "id": "2"
-            },
-            {
-                "position": "RIGHT_BACK",
-                "id": "3"
-            }
-        ]
-    },
-    "emotions": {
-        "host": "localhost",
-        "port": 5558
-    }
+  "zmq": {
+    "subscriber_port": 5555,
+    "publisher_port": 5556
+  },
+  "serial": {
+    "port": "/dev/serial0",
+    "baudrate": "1000000"
+  },
+  "gpio": {
+    "pin": 18
+  },
+  "vision": {
+    "webcam": 0
+  },
+  "servos": {
+    "wings": [
+      {
+        "position": "LEFT_FRONT",
+        "id": "1"
+      },
+      {
+        "position": "LEFT_BACK",
+        "id": "2"
+      },
+      {
+        "position": "RIGHT_FRONT",
+        "id": "3"
+      },
+      {
+        "position": "RIGHT_BACK",
+        "id": "4"
+      }
+    ]
+  },
+  "i2c": {
+    "device": "/dev/i2c-1"
+  },
+  "motor_controller": {
+    "address": "0x30",
+    "motors": [
+      {
+        "position": "LEFT_FRONT",
+        "id": "0"
+      },
+      {
+        "position": "LEFT_BACK",
+        "id": "1"
+      },
+      {
+        "position": "RIGHT_FRONT",
+        "id": "2"
+      },
+      {
+        "position": "RIGHT_BACK",
+        "id": "3"
+      }
+    ]
+  },
+  "emotions": {
+    "host": "localhost",
+    "port": 5558
+  },
+  "command_executor": {
+    "number_of_executors": 4
+  },
+  "watcher": {
+    "polling_rate": 250
+  }
 }

--- a/tests/test_config.cpp
+++ b/tests/test_config.cpp
@@ -76,6 +76,12 @@ BOOST_AUTO_TEST_SUITE(BOOST_TEST_MODULE)
         emotionsConfig->set_host("localhost");
         emotionsConfig->set_port(5558);
 
+        auto *commandExecutorConfig = new CommandExecutorConfig;
+        commandExecutorConfig->set_number_of_executors(4);
+
+        auto *watcherConfig = new WatcherConfig;
+        watcherConfig->set_polling_rate(250);
+
         configRepository.set_allocated_zmq(zmqConfig);
         configRepository.set_allocated_serial(serialConfig);
         configRepository.set_allocated_gpio(gpioConfig);
@@ -84,6 +90,8 @@ BOOST_AUTO_TEST_SUITE(BOOST_TEST_MODULE)
         configRepository.set_allocated_i2c(i2cConfig);
         configRepository.set_allocated_motor_controller(motorControllerConfig);
         configRepository.set_allocated_emotions(emotionsConfig);
+        configRepository.set_allocated_command_executor(commandExecutorConfig);
+        configRepository.set_allocated_watcher(watcherConfig);
 
         google::protobuf::util::MessageToJsonString(configRepository, &jsonString, options);
 


### PR DESCRIPTION
Use a boost thread pool for command pooling. Thread pool size is configurable through core-config.json.