### PR TITLE
Add QueueCommand and revise CommandExecutor to support parallel execution

### DIFF
--- a/src/controller/CMakeLists.txt
+++ b/src/controller/CMakeLists.txt
@@ -10,11 +10,12 @@ set(SOURCES
         commands/line_dance_command.cpp
         commands/obstacle_course_command.cpp
         commands/transport_rebuild_command.cpp
+        commands/queue_command.cpp
+        commands/basic_command.cpp
         command_map.cpp
         command_executor.cpp
         handles.h
-        handle_map.cpp
-        )
+        handle_map.cpp)
 
 add_library(${PROJECT_NAME} ${SOURCES})
 include_directories(${Boost_INCLUDE_DIRS})

--- a/src/controller/CMakeLists.txt
+++ b/src/controller/CMakeLists.txt
@@ -15,7 +15,8 @@ set(SOURCES
         command_map.cpp
         command_executor.cpp
         handles.h
-        handle_map.cpp)
+        handle_map.cpp
+        )
 
 add_library(${PROJECT_NAME} ${SOURCES})
 

--- a/src/controller/CMakeLists.txt
+++ b/src/controller/CMakeLists.txt
@@ -18,6 +18,8 @@ set(SOURCES
         handle_map.cpp)
 
 add_library(${PROJECT_NAME} ${SOURCES})
+
+find_package(Boost COMPONENTS system REQUIRED)
 include_directories(${Boost_INCLUDE_DIRS})
 
 add_definitions(-DBOOST_LOG_DYN_LINK)

--- a/src/controller/command_executor.cpp
+++ b/src/controller/command_executor.cpp
@@ -1,4 +1,5 @@
 #include "command_executor.h"
+#include "commands/queue_command.h"
 
 #include <boost/log/trivial.hpp>
 #include <cmath>
@@ -21,46 +22,59 @@ void CommandExecutor::run(const size_t commandId, const CommandMessage &message)
 
     auto &item = commands[commandId];
     if (item.status != CommandStatus::STALE) {
-        BOOST_LOG_TRIVIAL(warning) << "Command " << commandId << " was dropped because it was already running: "
-                                   << (item.status == CommandStatus::STARTING ? "STARTING" : "STARTED");
-        return;
+        if (!item.instance->canRunParallel()) {
+            BOOST_LOG_TRIVIAL(warning) << "Command " << commandId << " was dropped because it was already running: "
+                                       << (item.status == CommandStatus::STARTING ? "STARTING" : "STARTED");
+            return;
+        }
+
+        BOOST_LOG_TRIVIAL(warning) << "Command " << commandId << " was already running, running parallel.";
     }
     item.status = CommandStatus::STARTING;
 
-    numberOfActiveCommands++;
-    if (numberOfActiveCommands >= std::ceil(numberOfThreads * 0.75)) {
+    if (numberOfActiveCommands + 1 >= std::ceil(numberOfThreads * 0.75)) {
         BOOST_LOG_TRIVIAL(warning) << "Number of active commands is almost exceeding the number of command threads!"
                                    << " Execution of commands may be postponed.";
     }
-    boost::asio::post(pool, std::bind(&CommandExecutor::tryExecute, this, commandId, message));
+
+    auto requiredHandles = handles.getHandles(item.instance->getRequiredHandles());
+    auto starter = item.instance->canStart(requiredHandles) ? &CommandExecutor::start
+                                                            : &CommandExecutor::delayedStart;
+    boost::asio::post(pool, std::bind(starter, this, commandId, message));
 }
 
-void CommandExecutor::tryExecute(const size_t &commandId, const CommandMessage &message) {
+void CommandExecutor::start(const size_t &commandId, const CommandMessage &message) {
     std::unique_lock<std::mutex> lock(mutex);
-
+    numberOfActiveCommands++;
     CommandItem &item = commands[commandId];
+    item.status = CommandStatus::STARTED;
+
     auto requiredHandles = handles.getHandles(item.instance->getRequiredHandles());
-    if (canStart(*(item.instance))) {
-        item.status = CommandStatus::STARTED;
-        lock.unlock();
-
-        requiredHandles.lockAll(commandId);
-
-        BOOST_LOG_TRIVIAL(info) << "Execution of \"Command " << commandId << "\" has started";
-        try {
-            item.instance->run(requiredHandles, message);
-        } catch (std::exception &ex) {
-            BOOST_LOG_TRIVIAL(fatal) << "Error executing command \"" << commandId << "\" what(): " << ex.what();
-        }
-        BOOST_LOG_TRIVIAL(info) << "Execution of \"Command " << commandId << "\" has finished";
-
-        lock.lock();
-        item.status = CommandStatus::STALE;
-        numberOfActiveCommands--;
-        return;
-    }
+    requiredHandles.lockAll(commandId);
 
     lock.unlock();
+
+    BOOST_LOG_TRIVIAL(info) << "Execution of \"Command " << commandId << "\" has started";
+    try {
+        item.instance->run(requiredHandles, message);
+    } catch (std::exception &ex) {
+        BOOST_LOG_TRIVIAL(error) << "Error executing command \"" << commandId << "\" what(): " << ex.what();
+    }
+    BOOST_LOG_TRIVIAL(info) << "Execution of \"Command " << commandId << "\" has finished";
+
+    lock.lock();
+    item.status = CommandStatus::STALE;
+    numberOfActiveCommands--;
+}
+
+void CommandExecutor::delayedStart(const size_t &commandId, const CommandMessage &message) {
+    std::unique_lock<std::mutex> lock(mutex);
+    numberOfActiveCommands++;
+    CommandItem &item = commands[commandId];
+
+    lock.unlock();
+
+    auto requiredHandles = handles.getHandles(item.instance->getRequiredHandles());
     for (size_t handleId : item.instance->getRequiredHandles()) {
         if (handles[handleId]->isLocked(commandId)) {
             continue;
@@ -85,14 +99,4 @@ void CommandExecutor::tryExecute(const size_t &commandId, const CommandMessage &
     lock.lock();
     item.status = CommandStatus::STALE;
     numberOfActiveCommands--;
-}
-
-bool CommandExecutor::canStart(const Command &command) const {
-    for (const size_t handleId : command.getRequiredHandles()) {
-        if (handles[handleId]->isLocked() && handles[handleId]->getOwnerId() != command.getId()) {
-            return false;
-        }
-    }
-
-    return true;
 }

--- a/src/controller/command_executor.cpp
+++ b/src/controller/command_executor.cpp
@@ -4,9 +4,9 @@
 using namespace goliath::commands;
 
 CommandExecutor::CommandExecutor(CommandMap &commands, HandleMap &handles)
-        : commands(commands), handles(handles) { }
+        : commands(commands), handles(handles) {}
 
-CommandExecutor::~CommandExecutor() { }
+CommandExecutor::~CommandExecutor() {}
 
 void CommandExecutor::run(const size_t commandId, const CommandMessage &message) {
     std::lock_guard<std::mutex> lock(mutex);
@@ -16,7 +16,8 @@ void CommandExecutor::run(const size_t commandId, const CommandMessage &message)
 
     auto &item = commands[commandId];
     if (item.status != CommandStatus::STALE) {
-        BOOST_LOG_TRIVIAL(warning) << "Command " << commandId << " was dropped because it was already running";
+        BOOST_LOG_TRIVIAL(warning) << "Command " << commandId << " was dropped because it was already running: "
+                                   << (item.status == CommandStatus::STARTING ? "STARTING" : "STARTED");
         return;
     }
     item.status = CommandStatus::STARTING;
@@ -31,26 +32,30 @@ void CommandExecutor::tryExecute(const size_t &commandId, const CommandMessage &
     CommandItem &item = commands[commandId];
     auto requiredHandles = handles.getHandles(item.instance->getRequiredHandles());
     if (canStart(*(item.instance))) {
-        requiredHandles.lockAll(commandId);
         item.status = CommandStatus::STARTED;
         lock.unlock();
+
+        requiredHandles.lockAll(commandId);
 
         BOOST_LOG_TRIVIAL(info) << "Execution of \"Command " << commandId << "\" has started";
         try {
             item.instance->run(requiredHandles, message);
-        } catch (std::exception& ex) {
+        } catch (std::exception &ex) {
             BOOST_LOG_TRIVIAL(fatal) << "Error executing command \"" << commandId << "\" what(): " << ex.what();
         }
         BOOST_LOG_TRIVIAL(info) << "Execution of \"Command " << commandId << "\" has finished";
 
         lock.lock();
-        requiredHandles.unlockAll();
         item.status = CommandStatus::STALE;
         return;
     }
 
     lock.unlock();
     for (size_t handleId : item.instance->getRequiredHandles()) {
+        if (handles[handleId]->isLocked(commandId)) {
+            continue;
+        }
+
         size_t lockerId = handles[handleId]->getOwnerId();
         commands[lockerId].instance->interrupt();
         requiredHandles[handleId]->waitAndLock(commandId);
@@ -62,19 +67,18 @@ void CommandExecutor::tryExecute(const size_t &commandId, const CommandMessage &
     BOOST_LOG_TRIVIAL(info) << "* Execution of \"Command " << commandId << "\" has started";
     try {
         item.instance->run(requiredHandles, message);
-    } catch (std::exception& ex) {
+    } catch (std::exception &ex) {
         BOOST_LOG_TRIVIAL(fatal) << "Error executing command \"" << commandId << "\" what(): " << ex.what();
     }
     BOOST_LOG_TRIVIAL(info) << "* Execution of \"Command " << commandId << "\" has finished";
 
     lock.lock();
-    requiredHandles.unlockAll();
     item.status = CommandStatus::STALE;
 }
 
 bool CommandExecutor::canStart(const Command &command) const {
     for (const size_t handleId : command.getRequiredHandles()) {
-        if (handles[handleId]->isLocked()) {
+        if (handles[handleId]->isLocked() && handles[handleId]->getOwnerId() != command.getId()) {
             return false;
         }
     }

--- a/src/controller/command_executor.h
+++ b/src/controller/command_executor.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <boost/asio.hpp>
 #include "command_map.h"
 #include "handle_map.h"
 
@@ -21,7 +22,7 @@ namespace goliath::commands {
          * @param commands Command Map
          * @param handles Handle Map
          */
-        CommandExecutor(CommandMap& commands, HandleMap &handles);
+        CommandExecutor(size_t numberOfThreads, CommandMap& commands, HandleMap &handles);
         ~CommandExecutor();
 
         /**
@@ -31,15 +32,7 @@ namespace goliath::commands {
          * @param message Arguments gathered from the protobuf input
          */
         void run(size_t commandId, const CommandMessage &message);
-        /**
-         * @brief Running on it's own thread. Checks if the handles the command requires  are occupied. If so, call
-         * interrupt() on all command's currently using the handles the new command requires. After that waits for
-         * the condition variable to be triggered to then check again. If all handles are free, execute the command
-         * in the current thread. Sets status to started.
-         * @param commandId ID of the command to try to execute
-         * @param message Arguments gathered from the protobuf input
-         */
-        void tryExecute(const size_t &commandId, const CommandMessage &message);
+
         /**
          * @brief Checks if a command can start by checking all the handles it occupies
          * @param command Command to check the occupying handles of
@@ -47,11 +40,25 @@ namespace goliath::commands {
          */
         bool canStart(const Command &command) const;
     private:
-        std::vector<std::thread> threads;
+        const size_t numberOfThreads;
+        size_t numberOfActiveCommands;
 
         CommandMap& commands;
         HandleMap& handles;
 
+
+        boost::asio::thread_pool pool;
+
         std::mutex mutex;
+
+        /**
+         * Running on it's own thread. Checks if the handles the command requires  are occupied. If so, call
+         * interrupt() on all command's currently using the handles the new command requires. After that waits for
+         * the condition variable to be triggered to then check again. If all handles are free, execute the command
+         * in the current thread. Sets status to started.
+         * @param commandId ID of the command to try to execute
+         * @param message Arguments gathered from the protobuf input
+         */
+        void tryExecute(const size_t &commandId, const CommandMessage &message);
     };
 }

--- a/src/controller/command_executor.h
+++ b/src/controller/command_executor.h
@@ -22,7 +22,8 @@ namespace goliath::commands {
          * @param commands Command Map
          * @param handles Handle Map
          */
-        CommandExecutor(size_t numberOfThreads, CommandMap& commands, HandleMap &handles);
+        CommandExecutor(size_t numberOfThreads, CommandMap &commands, HandleMap &handles);
+
         ~CommandExecutor();
 
         /**
@@ -33,18 +34,12 @@ namespace goliath::commands {
          */
         void run(size_t commandId, const CommandMessage &message);
 
-        /**
-         * @brief Checks if a command can start by checking all the handles it occupies
-         * @param command Command to check the occupying handles of
-         * @return Whether or not all handles are free or not
-         */
-        bool canStart(const Command &command) const;
     private:
         const size_t numberOfThreads;
         size_t numberOfActiveCommands;
 
-        CommandMap& commands;
-        HandleMap& handles;
+        CommandMap &commands;
+        HandleMap &handles;
 
 
         boost::asio::thread_pool pool;
@@ -59,6 +54,8 @@ namespace goliath::commands {
          * @param commandId ID of the command to try to execute
          * @param message Arguments gathered from the protobuf input
          */
-        void tryExecute(const size_t &commandId, const CommandMessage &message);
+        void start(const size_t &commandId, const CommandMessage &message);
+
+        void delayedStart(const size_t &commandId, const CommandMessage &message);
     };
 }

--- a/src/controller/commands/basic_command.cpp
+++ b/src/controller/commands/basic_command.cpp
@@ -1,0 +1,14 @@
+#include "basic_command.h"
+
+using namespace goliath::commands;
+
+BasicCommand::BasicCommand(const size_t &id, const std::vector<size_t> &requiredHandles) : Command(id,
+                                                                                                   requiredHandles) {}
+
+void BasicCommand::run(goliath::handles::HandleMap &handles, const CommandMessage &message) {
+    running = true;
+    BOOST_LOG_TRIVIAL(debug) << "Command " << std::to_string(getId()) << " is being executed";
+    execute(handles, message);
+    BOOST_LOG_TRIVIAL(debug) << "Command " << std::to_string(getId()) << " has finished";
+    running = false;
+}

--- a/src/controller/commands/basic_command.cpp
+++ b/src/controller/commands/basic_command.cpp
@@ -10,5 +10,6 @@ void BasicCommand::run(goliath::handles::HandleMap &handles, const CommandMessag
     BOOST_LOG_TRIVIAL(debug) << "Command " << std::to_string(getId()) << " is being executed";
     execute(handles, message);
     BOOST_LOG_TRIVIAL(debug) << "Command " << std::to_string(getId()) << " has finished";
+    handles.unlockAll();
     running = false;
 }

--- a/src/controller/commands/basic_command.h
+++ b/src/controller/commands/basic_command.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "command.h"
+
+namespace goliath::commands {
+    class BasicCommand : public Command {
+    public:
+        BasicCommand(const size_t &id, const std::vector<size_t> &requiredHandles);
+
+        void run(handles::HandleMap &handles, const CommandMessage &message) override;
+    protected:
+        /**
+         * @brief The actual execute method implemented by underlying commands
+         * @param handles Handle map to be passed to implementation to be unlocked dynamically
+         * @param message Arguments to be passed to implementers
+         */
+        virtual void execute(handles::HandleMap &handles, const CommandMessage &message) = 0;
+    };
+}

--- a/src/controller/commands/command.cpp
+++ b/src/controller/commands/command.cpp
@@ -4,8 +4,7 @@
 using namespace goliath::commands;
 
 Command::Command(const size_t &id, const std::vector<size_t> &requiredHandles)
-        : id(id), requiredHandles(requiredHandles) {
-}
+        : running(false), id(id), interrupted(false), requiredHandles(requiredHandles) { }
 
 void Command::interrupt() {
     interrupted = true;
@@ -21,4 +20,20 @@ const std::vector<size_t>& Command::getRequiredHandles() const {
 
 size_t Command::getId() const {
     return id;
+}
+
+void Command::onInterrupt() { }
+
+bool Command::canStart(const goliath::handles::HandleMap &handles) const {
+    for (const size_t handleId : getRequiredHandles()) {
+        if (handles[handleId]->isLocked() && handles[handleId]->getOwnerId() != getId()) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+bool Command::canRunParallel() const {
+    return false;
 }

--- a/src/controller/commands/command.cpp
+++ b/src/controller/commands/command.cpp
@@ -19,14 +19,6 @@ const std::vector<size_t>& Command::getRequiredHandles() const {
     return requiredHandles;
 }
 
-void Command::run(const goliath::handles::HandleMap &handles, const CommandMessage& message) {
-    running = true;
-    BOOST_LOG_TRIVIAL(debug) << "Command " << std::to_string(getId()) << " is being executed";
-    execute(handles, message);
-    BOOST_LOG_TRIVIAL(debug) << "Command " << std::to_string(getId()) << " has finished";
-    running = false;
-}
-
 size_t Command::getId() const {
     return id;
 }

--- a/src/controller/commands/command.cpp
+++ b/src/controller/commands/command.cpp
@@ -8,6 +8,7 @@ Command::Command(const size_t &id, const std::vector<size_t> &requiredHandles)
 
 void Command::interrupt() {
     interrupted = true;
+    onInterrupt();
 }
 
 bool Command::isInterrupted() const {

--- a/src/controller/commands/command.h
+++ b/src/controller/commands/command.h
@@ -54,11 +54,22 @@ namespace goliath::commands {
          */
         const std::vector<size_t> &getRequiredHandles() const;
 
+        /**
+         * @brief Checks if a command can start by checking all the handles it occupies
+         * @param command Command to check the occupying handles of
+         * @return Whether or not all handles are free or not
+         */
+        virtual bool canStart(const handles::HandleMap &handles) const;
+
+        virtual bool canRunParallel() const;
+
     protected:
         /**
          * @brief Represents whether a command is currently running
          */
-        bool running = false;
+        bool running;
+
+        virtual void onInterrupt();
 
     private:
         const size_t id;
@@ -66,7 +77,7 @@ namespace goliath::commands {
         /**
          * @brief Represents whether a command is interrupted or not
          */
-        bool interrupted = false;
+        bool interrupted;
 
         /**
          * @brief Handle this command requires

--- a/src/controller/commands/command.h
+++ b/src/controller/commands/command.h
@@ -10,10 +10,10 @@
  * @author Group 7 - Informatica
  */
 
- /**
-  * @namespace goliath::commands
-  * @brief Contains all command and command utilities
-  */
+/**
+ * @namespace goliath::commands
+ * @brief Contains all command and command utilities
+ */
 
 namespace goliath::commands {
 
@@ -35,12 +35,13 @@ namespace goliath::commands {
          * @param handles Handle map to be passed to implementation to be unlocked dynamically
          * @param message Arguments to be passed
          */
-        void run(const handles::HandleMap &handles, const CommandMessage &message);
+        virtual void run(handles::HandleMap &handles, const CommandMessage &message) = 0;
 
         /**
          * @brief Interrupt a command by setting the interrupted property
          */
         void interrupt();
+
         /**
          * @brief Method to check wether a command is already interrupted
          * @return The value of interrupted
@@ -51,15 +52,13 @@ namespace goliath::commands {
          * @brief Handle getter
          * @return The handles this specific command requires
          */
-        const std::vector<size_t>& getRequiredHandles() const;
+        const std::vector<size_t> &getRequiredHandles() const;
 
     protected:
         /**
-         * @brief The actual execute method implemented by underlying commands
-         * @param handles Handle map to be passed to implementation to be unlocked dynamically
-         * @param message Arguments to be passed to implementers
+         * @brief Represents whether a command is currently running
          */
-        virtual void execute(const handles::HandleMap &handles, const CommandMessage &message) = 0;
+        bool running = false;
 
     private:
         const size_t id;
@@ -68,10 +67,7 @@ namespace goliath::commands {
          * @brief Represents whether a command is interrupted or not
          */
         bool interrupted = false;
-        /**
-         * @brief Represents whether a command is currently running
-         */
-        bool running = false;
+
         /**
          * @brief Handle this command requires
          */

--- a/src/controller/commands/dance_command.cpp
+++ b/src/controller/commands/dance_command.cpp
@@ -10,10 +10,10 @@ using namespace goliath::handles;
 using namespace goliath;
 
 commands::DanceCommand::DanceCommand(const size_t& id)
-    : Command(id, {HANDLE_EMOTIONS}) {
+    : BasicCommand(id, {HANDLE_EMOTIONS}) {
 }
 
-void commands::DanceCommand::execute(const HandleMap& handles, const CommandMessage& message) {
+void commands::DanceCommand::execute(HandleMap& handles, const CommandMessage& message) {
     std::shared_ptr<emotions::EmotionPublisher> publisher = std::static_pointer_cast<EmotionHandle>(
         handles[HANDLE_CAM])->getPublisher();
 

--- a/src/controller/commands/dance_command.h
+++ b/src/controller/commands/dance_command.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "../handles.h"
-#include "command.h"
+#include "basic_command.h"
 
 /**
  * @file dance_command.h
@@ -9,11 +9,11 @@
  */
 
 namespace goliath::commands {
-    class DanceCommand : public Command {
+    class DanceCommand : public BasicCommand {
     public:
         DanceCommand(const size_t &id);
 
     private:
-        void execute(const handles::HandleMap &handles, const CommandMessage &message) override;
+        void execute(handles::HandleMap &handles, const CommandMessage &message) override;
     };
 }

--- a/src/controller/commands/line_dance_command.cpp
+++ b/src/controller/commands/line_dance_command.cpp
@@ -3,10 +3,10 @@
 using namespace goliath;
 
 commands::LineDanceCommand::LineDanceCommand(const size_t& id)
-        : Command(id, {HANDLE_LEFT_FRONT_WING_SERVO, HANDLE_LEFT_BACK_WING_SERVO, HANDLE_RIGHT_FRONT_WING_SERVO,
+        : BasicCommand(id, {HANDLE_LEFT_FRONT_WING_SERVO, HANDLE_LEFT_BACK_WING_SERVO, HANDLE_RIGHT_FRONT_WING_SERVO,
                        HANDLE_RIGHT_BACK_WING_SERVO}) { // TODO: Add motor handles
 }
 
-void commands::LineDanceCommand::execute(const goliath::handles::HandleMap& handles, const CommandMessage& message) {
+void commands::LineDanceCommand::execute(handles::HandleMap& handles, const CommandMessage& message) {
     // TODO: Implement line dance
 }

--- a/src/controller/commands/line_dance_command.h
+++ b/src/controller/commands/line_dance_command.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "command.h"
+#include "basic_command.h"
 #include "../handles.h"
 
 /**
@@ -9,11 +9,11 @@
  */
 
 namespace goliath::commands {
-    class LineDanceCommand : public Command {
+    class LineDanceCommand : public BasicCommand {
     public:
         explicit LineDanceCommand(const size_t &id);
 
     private:
-        void execute(const handles::HandleMap &handles, const CommandMessage &message) override;
+        void execute(handles::HandleMap &handles, const CommandMessage &message) override;
     };
 }

--- a/src/controller/commands/move_command.cpp
+++ b/src/controller/commands/move_command.cpp
@@ -37,8 +37,4 @@ void commands::MoveCommand::execute(HandleMap &handles, const CommandMessage &me
         commands.emplace_back(motorCommand);
     }
     motorController.sendCommands(commands.begin(), commands.end());
-
-    for (auto const &lockedHandle: getRequiredHandles()) {
-        handles[lockedHandle]->unlock();
-    }
 }

--- a/src/controller/commands/move_command.cpp
+++ b/src/controller/commands/move_command.cpp
@@ -9,10 +9,10 @@ using namespace goliath::handles;
 using namespace goliath;
 
 commands::MoveCommand::MoveCommand(const size_t &id)
-        : Command(id, {HANDLE_I2C_BUS, HANDLE_MOTOR_CONTROLLER, HANDLE_LEFT_FRONT_MOTOR}) {
+        : QueueCommand(id, {HANDLE_I2C_BUS, HANDLE_MOTOR_CONTROLLER, HANDLE_LEFT_FRONT_MOTOR}) {
 }
 
-void commands::MoveCommand::execute(const HandleMap &handles, const CommandMessage &message) {
+void commands::MoveCommand::execute(HandleMap &handles, const CommandMessage &message) {
     i2c::I2cSlave controllerSlave(*handles.get<handles::I2cBusHandle>(HANDLE_I2C_BUS),
                                   *handles.get<handles::I2cSlaveHandle>(HANDLE_MOTOR_CONTROLLER));
     motor_controller::MotorController motorController(controllerSlave);

--- a/src/controller/commands/move_command.h
+++ b/src/controller/commands/move_command.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "../handles.h"
-#include "command.h"
+#include "queue_command.h"
 
 /**
  * @file move_command.h
@@ -9,12 +9,12 @@
  */
 
 namespace goliath::commands {
-    class MoveCommand : public Command {
+    class MoveCommand : public QueueCommand {
     public:
         MoveCommand(const size_t &id);
 
     private:
-        void execute(const handles::HandleMap &handles, const CommandMessage &message) override;
+        void execute(handles::HandleMap &handles, const CommandMessage &message) override;
 
         const std::map<size_t, size_t> commandMotorToHandleMap = {{
                                                                     {::MotorCommand::Motor::MotorCommand_Motor_LEFT_FRONT, HANDLE_LEFT_FRONT_MOTOR},

--- a/src/controller/commands/move_tower_command.cpp
+++ b/src/controller/commands/move_tower_command.cpp
@@ -7,10 +7,10 @@ using namespace goliath::handles;
 using namespace goliath;
 
 commands::MoveTowerCommand::MoveTowerCommand(const size_t &id)
-        : Command(id, { HANDLE_CAM }) {
+        : BasicCommand(id, { HANDLE_CAM }) {
 }
 
-void commands::MoveTowerCommand::execute(const HandleMap &handles, const CommandMessage &message) {
+void commands::MoveTowerCommand::execute(HandleMap &handles, const CommandMessage &message) {
     BOOST_LOG_TRIVIAL(info) << "Execution of move tower command has started";
     std::this_thread::sleep_for(std::chrono::milliseconds(2000));
     if (isInterrupted()) {

--- a/src/controller/commands/move_tower_command.h
+++ b/src/controller/commands/move_tower_command.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "command.h"
+#include "basic_command.h"
 #include "../handles.h"
 
 /**
@@ -9,12 +9,12 @@
  */
 
 namespace goliath::commands {
-    class MoveTowerCommand : public Command {
+    class MoveTowerCommand : public BasicCommand {
     public:
         MoveTowerCommand(const size_t &id);
 
     private:
-        void execute(const handles::HandleMap& handles, const CommandMessage &message) override ;
+        void execute(handles::HandleMap& handles, const CommandMessage &message) override;
 
     };
 }

--- a/src/controller/commands/move_wing_command.cpp
+++ b/src/controller/commands/move_wing_command.cpp
@@ -30,11 +30,6 @@ void commands::MoveWingCommand::execute(HandleMap &handles, const CommandMessage
         }
     }
 
-    // Unlock handles
-    for (auto const &lockedHandle: requiredHandles) {
-        handles[lockedHandle]->unlock();
-    }
-
     BOOST_LOG_TRIVIAL(info) << "Execution of move wing command has finished";
 }
 

--- a/src/controller/commands/move_wing_command.cpp
+++ b/src/controller/commands/move_wing_command.cpp
@@ -6,11 +6,11 @@ using namespace goliath;
 using namespace goliath::handles;
 
 commands::MoveWingCommand::MoveWingCommand(const size_t &id)
-        : Command(id, {HANDLE_LEFT_FRONT_WING_SERVO, HANDLE_LEFT_BACK_WING_SERVO,
+        : BasicCommand(id, {HANDLE_LEFT_FRONT_WING_SERVO, HANDLE_LEFT_BACK_WING_SERVO,
                        HANDLE_RIGHT_FRONT_WING_SERVO, HANDLE_RIGHT_BACK_WING_SERVO}) {
 }
 
-void commands::MoveWingCommand::execute(const HandleMap &handles, const CommandMessage &message) {
+void commands::MoveWingCommand::execute(HandleMap &handles, const CommandMessage &message) {
     BOOST_LOG_TRIVIAL(info) << "Execution of move wing command has started";
     ::MoveWingCommand wingCommand = message.movewingcommand();
 

--- a/src/controller/commands/move_wing_command.h
+++ b/src/controller/commands/move_wing_command.h
@@ -1,16 +1,18 @@
 #pragma once
 
-#include "command.h"
-#include "../handles.h"
 #include <goliath/servo.h>
 
+#include "basic_command.h"
+#include "../handles.h"
+
+
 namespace goliath::commands {
-    class MoveWingCommand : public Command {
+    class MoveWingCommand : public BasicCommand {
     public:
         MoveWingCommand(const size_t &id);
 
     private:
-        void execute(const handles::HandleMap &handles, const CommandMessage &message) override;
+        void execute(handles::HandleMap &handles, const CommandMessage &message) override;
 
         void executeServoCommand(std::shared_ptr<handles::ServoHandle> servoHandle, const ServoCommand &servoCommand);
 

--- a/src/controller/commands/obstacle_course_command.cpp
+++ b/src/controller/commands/obstacle_course_command.cpp
@@ -3,10 +3,10 @@
 using namespace goliath;
 
 commands::ObstacleCourseCommand::ObstacleCourseCommand(const size_t& id)
-        : Command(id, {HANDLE_LEFT_FRONT_WING_SERVO, HANDLE_LEFT_BACK_WING_SERVO, HANDLE_RIGHT_FRONT_WING_SERVO,
+        : BasicCommand(id, {HANDLE_LEFT_FRONT_WING_SERVO, HANDLE_LEFT_BACK_WING_SERVO, HANDLE_RIGHT_FRONT_WING_SERVO,
                        HANDLE_RIGHT_BACK_WING_SERVO}) { // TODO: Add motor handles
 }
 
-void commands::ObstacleCourseCommand::execute(const goliath::handles::HandleMap& handles, const CommandMessage& message) {
+void commands::ObstacleCourseCommand::execute(handles::HandleMap& handles, const CommandMessage& message) {
     // TODO: Implement obstacle course command
 }

--- a/src/controller/commands/obstacle_course_command.h
+++ b/src/controller/commands/obstacle_course_command.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "command.h"
+#include "basic_command.h"
 #include "../handles.h"
 
 /**
@@ -9,11 +9,11 @@
  */
 
 namespace goliath::commands {
-    class ObstacleCourseCommand : public Command {
+    class ObstacleCourseCommand : public BasicCommand {
     public:
         explicit ObstacleCourseCommand(const size_t &id);
 
     private:
-        void execute(const handles::HandleMap &handles, const CommandMessage &message) override;
+        void execute(handles::HandleMap &handles, const CommandMessage &message) override;
     };
 }

--- a/src/controller/commands/queue_command.cpp
+++ b/src/controller/commands/queue_command.cpp
@@ -1,0 +1,67 @@
+#include "queue_command.h"
+
+#include <thread>
+
+using namespace goliath::commands;
+
+QueueCommand::QueueCommand(const size_t &id, const std::vector<size_t> &requiredHandles) : Command(id,
+                                                                                                   requiredHandles),
+                                                                                           queue{},
+                                                                                           isWorking(true),
+                                                                                           worker(&QueueCommand::work,
+                                                                                                  this) {}
+
+void QueueCommand::run(goliath::handles::HandleMap &handles, const CommandMessage &message) {
+    std::lock_guard<std::mutex> lock(mutex);
+
+    this->handles = handles;
+    CommandMessage copy = message;
+    queue.emplace(copy);
+
+    cv.notify_all();
+}
+
+void QueueCommand::work() {
+    std::unique_lock<std::mutex> lock(mutex);
+
+    while (isWorking) {
+        cv.wait(lock, [&]() {
+            return !isWorking || !queue.empty() || isInterrupted();
+        });
+
+        BOOST_LOG_TRIVIAL(info) << "Worker has been awakened";
+
+        if (!isWorking || isInterrupted()) {
+            break;
+        }
+
+        running = true;
+        while (!queue.empty() && !isInterrupted()) {
+            handles::HandleMap handles = this->handles;
+            CommandMessage message = queue.front();
+            queue.pop();
+            lock.unlock();
+
+            try {
+                execute(handles, message);
+            } catch (std::exception &ex) {
+                BOOST_LOG_TRIVIAL(fatal) << "Error executing command \"" << getId() << "\" what(): "
+                                         << ex.what();
+            }
+            lock.lock();
+        }
+        lock.unlock();
+        handles.unlockAll();
+        running = false;
+
+        BOOST_LOG_TRIVIAL(info) << "Worker has finished working";
+    }
+}
+
+QueueCommand::~QueueCommand() {
+    std::unique_lock<std::mutex> lock(mutex);
+
+    isWorking = false;
+    cv.notify_one();
+    worker.join();
+}

--- a/src/controller/commands/queue_command.cpp
+++ b/src/controller/commands/queue_command.cpp
@@ -4,32 +4,34 @@
 
 using namespace goliath::commands;
 
-QueueCommand::QueueCommand(const size_t &id, const std::vector<size_t> &requiredHandles) : Command(id,
-                                                                                                   requiredHandles),
-                                                                                           queue{},
-                                                                                           isWorking(true),
-                                                                                           worker(&QueueCommand::work,
-                                                                                                  this) {}
+QueueCommand::QueueCommand(const size_t &id, const std::vector<size_t> &requiredHandles)
+        : Command(id, requiredHandles), queue{}, isWorking(true), worker(&QueueCommand::work, this) {}
 
 void QueueCommand::run(goliath::handles::HandleMap &handles, const CommandMessage &message) {
     std::lock_guard<std::mutex> lock(mutex);
+
+    if (!isWorking) {
+        BOOST_LOG_TRIVIAL(warning) << "Worker isn't working, please restart";
+        return;
+    }
 
     this->handles = handles;
     CommandMessage copy = message;
     queue.emplace(copy);
 
-    cv.notify_all();
+    cv.notify_one();
 }
 
 void QueueCommand::work() {
     std::unique_lock<std::mutex> lock(mutex);
 
     while (isWorking) {
+        BOOST_LOG_TRIVIAL(debug) << "Worker has started working... waiting for messages";
         cv.wait(lock, [&]() {
-            return !isWorking || !queue.empty() || isInterrupted();
+            return !isWorking || isInterrupted() || !queue.empty();
         });
 
-        BOOST_LOG_TRIVIAL(info) << "Worker has been awakened";
+        BOOST_LOG_TRIVIAL(debug) << "Worker has been awakened";
 
         if (!isWorking || isInterrupted()) {
             break;
@@ -45,23 +47,36 @@ void QueueCommand::work() {
             try {
                 execute(handles, message);
             } catch (std::exception &ex) {
-                BOOST_LOG_TRIVIAL(fatal) << "Error executing command \"" << getId() << "\" what(): "
+                BOOST_LOG_TRIVIAL(error) << "Error executing command \"" << getId() << "\" what(): "
                                          << ex.what();
             }
+
             lock.lock();
         }
-        lock.unlock();
         handles.unlockAll();
         running = false;
 
-        BOOST_LOG_TRIVIAL(info) << "Worker has finished working";
+        BOOST_LOG_TRIVIAL(debug) << "Worker has finished working";
     }
+    BOOST_LOG_TRIVIAL(debug) << "Worker has exited";
 }
 
 QueueCommand::~QueueCommand() {
     std::unique_lock<std::mutex> lock(mutex);
 
+    if (!isWorking) {
+
+    }
+
     isWorking = false;
     cv.notify_one();
     worker.join();
+}
+
+void QueueCommand::onInterrupt() {
+    cv.notify_one();
+}
+
+bool QueueCommand::canRunParallel() const {
+    return true;
 }

--- a/src/controller/commands/queue_command.cpp
+++ b/src/controller/commands/queue_command.cpp
@@ -65,7 +65,7 @@ QueueCommand::~QueueCommand() {
     std::unique_lock<std::mutex> lock(mutex);
 
     if (!isWorking) {
-
+        return;
     }
 
     isWorking = false;

--- a/src/controller/commands/queue_command.h
+++ b/src/controller/commands/queue_command.h
@@ -11,19 +11,22 @@ namespace goliath::commands {
 
         void run(handles::HandleMap &handles, const CommandMessage &message) override;
 
+        bool canRunParallel() const override;
+
     protected:
         virtual void execute(handles::HandleMap &handles, const CommandMessage &message) = 0;
 
+        void onInterrupt() override;
     private:
         void work();
 
         handles::HandleMap handles;
         std::queue<CommandMessage> queue;
 
-        bool isWorking;
-        std::thread worker;
-
         std::mutex mutex;
         std::condition_variable cv;
+
+        bool isWorking;
+        std::thread worker;
     };
 }

--- a/src/controller/commands/queue_command.h
+++ b/src/controller/commands/queue_command.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "command.h"
+
+namespace goliath::commands {
+    class QueueCommand : public Command {
+    public:
+        QueueCommand(const size_t &id, const std::vector<size_t> &requiredHandles);
+
+        ~QueueCommand();
+
+        void run(handles::HandleMap &handles, const CommandMessage &message) override;
+
+    protected:
+        virtual void execute(handles::HandleMap &handles, const CommandMessage &message) = 0;
+
+    private:
+        void work();
+
+        handles::HandleMap handles;
+        std::queue<CommandMessage> queue;
+
+        bool isWorking;
+        std::thread worker;
+
+        std::mutex mutex;
+        std::condition_variable cv;
+    };
+}

--- a/src/controller/commands/transport_rebuild_command.cpp
+++ b/src/controller/commands/transport_rebuild_command.cpp
@@ -3,10 +3,10 @@
 using namespace goliath;
 
 commands::TransportRebuildCommand::TransportRebuildCommand(const size_t& id)
-        : Command(id, {HANDLE_LEFT_FRONT_WING_SERVO, HANDLE_LEFT_BACK_WING_SERVO, HANDLE_RIGHT_FRONT_WING_SERVO,
+        : BasicCommand(id, {HANDLE_LEFT_FRONT_WING_SERVO, HANDLE_LEFT_BACK_WING_SERVO, HANDLE_RIGHT_FRONT_WING_SERVO,
                        HANDLE_RIGHT_BACK_WING_SERVO}) { // TODO: Add motor handles
 }
 
-void commands::TransportRebuildCommand::execute(const goliath::handles::HandleMap& handles, const CommandMessage& message) {
+void commands::TransportRebuildCommand::execute(handles::HandleMap& handles, const CommandMessage& message) {
     // TODO: Implement transport rebuild command
 }

--- a/src/controller/commands/transport_rebuild_command.h
+++ b/src/controller/commands/transport_rebuild_command.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "command.h"
+#include "basic_command.h"
 #include "../handles.h"
 
 /**
@@ -9,11 +9,11 @@
  */
 
 namespace goliath::commands {
-    class TransportRebuildCommand : public Command {
+    class TransportRebuildCommand : public BasicCommand {
     public:
         explicit TransportRebuildCommand(const size_t &id);
 
     private:
-        void execute(const handles::HandleMap &handles, const CommandMessage &message) override;
+        void execute(handles::HandleMap &handles, const CommandMessage &message) override;
     };
 }

--- a/src/controller/commands/wunderhorn_command.cpp
+++ b/src/controller/commands/wunderhorn_command.cpp
@@ -9,10 +9,10 @@ using namespace goliath::handles;
 using namespace goliath;
 
 commands::WunderhornCommand::WunderhornCommand(const size_t& id)
-    : Command(id, {HANDLE_CAM}) {
+    : BasicCommand(id, {HANDLE_CAM}) {
 }
 
-void commands::WunderhornCommand::execute(const HandleMap& handles, const CommandMessage& message) {
+void commands::WunderhornCommand::execute(HandleMap& handles, const CommandMessage& message) {
     vision::Webcam webcam = std::static_pointer_cast<WebcamHandle>(handles[HANDLE_CAM])->getDevice();
     vision::FollowLineDetector followLineDetector(webcam.getFrame(), 4, 80, 20, 20, 10, 10000);
 

--- a/src/controller/commands/wunderhorn_command.h
+++ b/src/controller/commands/wunderhorn_command.h
@@ -3,7 +3,7 @@
 #include <goliath/vision.h>
 
 #include "../handles.h"
-#include "command.h"
+#include "basic_command.h"
 
 /**
  * @file follow_line_command.h
@@ -15,7 +15,7 @@ namespace goliath::commands {
      * @class goliath::commands::WunderhornCommand
      * @brief Command that follows a line and pauses on a coled area in the center
      */
-    class WunderhornCommand : public Command {
+    class WunderhornCommand : public BasicCommand {
     public:
         /**
          * @param id Command ID
@@ -24,7 +24,7 @@ namespace goliath::commands {
         WunderhornCommand(const size_t &id);
 
     private:
-        void execute(const handles::HandleMap &handles, const CommandMessage &message) override;
+        void execute(handles::HandleMap &handles, const CommandMessage &message) override;
         /**
          * @brief Follows a straight line until it stops
          * @param followLineDetector Detector

--- a/src/controller/handle_map.cpp
+++ b/src/controller/handle_map.cpp
@@ -43,7 +43,9 @@ const std::shared_ptr<Handle> &HandleMap::operator[](const size_t &index) const 
 
 void HandleMap::lockAll(const size_t &commandId) {
     for (auto handle : map) {
-        handle.second->lock(commandId);
+        if (!handle.second->isLocked(commandId)) {
+            handle.second->lock(commandId);
+        }
     }
 }
 
@@ -62,3 +64,5 @@ std::map<size_t, std::shared_ptr<Handle>>::iterator HandleMap::begin() {
 std::map<size_t, std::shared_ptr<Handle>>::iterator HandleMap::end() {
     return map.end();
 }
+
+HandleMap::HandleMap(const HandleMap &other) : map(other.map) { }

--- a/src/controller/handle_map.h
+++ b/src/controller/handle_map.h
@@ -19,6 +19,7 @@ namespace goliath::handles {
          * @param map Starting map
          */
         explicit HandleMap(const std::map<size_t, std::shared_ptr<Handle>> &map);
+        HandleMap(const HandleMap &other);
         ~HandleMap();
 
         /**

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -54,7 +54,7 @@ int main(int argc, char *argv[]) {
     emotions::EmotionPublisher emotionPublisher(context, config->emotions().host(), config->emotions().port());
 
     BOOST_LOG_TRIVIAL(info) << "Setting up watcher";
-    repositories::Watcher watcher(500, publisher);
+    repositories::Watcher watcher(config->watcher().polling_rate(), publisher);
     auto battery_repo = std::make_shared<repositories::BatteryRepository>();
     watcher.watch(battery_repo);
 
@@ -123,7 +123,7 @@ int main(int argc, char *argv[]) {
     commands.add<commands::WunderhornCommand>(CommandMessage::kWunderhornCommand);
     commands.add<commands::MoveTowerCommand>(CommandMessage::kMoveTowerCommand);
 
-    commands::CommandExecutor runner(commands, handles);
+    commands::CommandExecutor runner(config->command_executor().number_of_executors(), commands, handles);
 
     subscriber.bind(MessageCarrier::MessageCase::kCommandMessage, [&runner](const MessageCarrier &carrier) {
         CommandMessage message = carrier.commandmessage();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -59,7 +59,8 @@ int main(int argc, char *argv[]) {
     watcher.watch(battery_repo);
 
     BOOST_LOG_TRIVIAL(info) << "Setting up GPIO";
-    gpio::GPIO gpio(static_cast<gpio::GPIO::MapPin>(config->gpio().pin()), gpio::GPIO::Direction::Out, gpio::GPIO::State::Low);
+    gpio::GPIO gpio(static_cast<gpio::GPIO::MapPin>(config->gpio().pin()), gpio::GPIO::Direction::Out,
+                    gpio::GPIO::State::Low);
     std::function<void(bool)> callback = [&gpio](bool isTx) {
         if (isTx) {
             gpio.set(gpio::GPIO::State::High);
@@ -91,7 +92,7 @@ int main(int argc, char *argv[]) {
 
         std::map<std::string, int> servos;
 
-        for(Wing wing : config->servos().wings()) {
+        for (Wing wing : config->servos().wings()) {
             std::shared_ptr<Dynamixel> dynamixel = std::make_shared<Dynamixel>(wing.id(), port);
 
             size_t handle;

--- a/src/resources/core-config.json
+++ b/src/resources/core-config.json
@@ -1,64 +1,70 @@
 {
-    "zmq": {
-        "subscriber_port": 5555,
-        "publisher_port": 5556
-    },
-    "serial": {
-        "port": "/dev/serial0",
-        "baudrate": "1000000"
-    },
-    "gpio": {
-        "pin": 18
-    },
-    "vision": {
-        "webcam": 0
-    },
-    "servos": {
-        "wings": [
-            {
-                "position": "LEFT_FRONT",
-                "id": "1"
-            },
-            {
-                "position": "LEFT_BACK",
-                "id": "2"
-            },
-            {
-                "position": "RIGHT_FRONT",
-                "id": "3"
-            },
-            {
-                "position": "RIGHT_BACK",
-                "id": "4"
-            }
-        ]
-    },
-    "i2c": {
-        "device": "/dev/i2c-1"
-    },
-    "motor_controller": {
-        "address": "0x30",
-        "motors": [
-            {
-                "position": "LEFT_FRONT",
-                "id": "0"
-            },
-            {
-                "position": "LEFT_BACK",
-                "id": "1"
-            },
-            {
-                "position": "RIGHT_FRONT",
-                "id": "2"
-            },
-            {
-                "position": "RIGHT_BACK",
-                "id": "3"
-            }
-        ]
-    },
-    "emotions": {
-        "host": "localhost",
-        "port": 5558
-    }
+  "zmq": {
+    "subscriber_port": 5555,
+    "publisher_port": 5556
+  },
+  "serial": {
+    "port": "/dev/serial0",
+    "baudrate": "1000000"
+  },
+  "gpio": {
+    "pin": 18
+  },
+  "vision": {
+    "webcam": 0
+  },
+  "servos": {
+    "wings": [
+      {
+        "position": "LEFT_FRONT",
+        "id": "1"
+      },
+      {
+        "position": "LEFT_BACK",
+        "id": "2"
+      },
+      {
+        "position": "RIGHT_FRONT",
+        "id": "3"
+      },
+      {
+        "position": "RIGHT_BACK",
+        "id": "4"
+      }
+    ]
+  },
+  "i2c": {
+    "device": "/dev/i2c-1"
+  },
+  "motor_controller": {
+    "address": "0x30",
+    "motors": [
+      {
+        "position": "LEFT_FRONT",
+        "id": "0"
+      },
+      {
+        "position": "LEFT_BACK",
+        "id": "1"
+      },
+      {
+        "position": "RIGHT_FRONT",
+        "id": "2"
+      },
+      {
+        "position": "RIGHT_BACK",
+        "id": "3"
+      }
+    ]
+  },
+  "emotions": {
+    "host": "localhost",
+    "port": 5558
+  },
+  "command_executor": {
+    "number_of_executors": 4
+  },
+  "watcher": {
+    "polling_rate": 250
+  }
 }

--- a/tests/test_config.cpp
+++ b/tests/test_config.cpp
@@ -76,6 +76,12 @@ BOOST_AUTO_TEST_SUITE(BOOST_TEST_MODULE)
         emotionsConfig->set_host("localhost");
         emotionsConfig->set_port(5558);
 
+        auto *commandExecutorConfig = new CommandExecutorConfig;
+        commandExecutorConfig->set_number_of_executors(4);
+
+        auto *watcherConfig = new WatcherConfig;
+        watcherConfig->set_polling_rate(250);
+
         configRepository.set_allocated_zmq(zmqConfig);
         configRepository.set_allocated_serial(serialConfig);
         configRepository.set_allocated_gpio(gpioConfig);
@@ -84,6 +90,8 @@ BOOST_AUTO_TEST_SUITE(BOOST_TEST_MODULE)
         configRepository.set_allocated_i2c(i2cConfig);
         configRepository.set_allocated_motor_controller(motorControllerConfig);
         configRepository.set_allocated_emotions(emotionsConfig);
+        configRepository.set_allocated_command_executor(commandExecutorConfig);
+        configRepository.set_allocated_watcher(watcherConfig);
 
         google::protobuf::util::MessageToJsonString(configRepository, &jsonString, options);
 


### PR DESCRIPTION
- Split all commands in QueueCommand and BasicCommand
  - Add QueueCommand to support semi-realtime commands without dropping them in the executor
  - BasicCommand is the same a the previous Command.
- Changed CommandExecutor to account for commands which can be executed in parallel.
  